### PR TITLE
fix: Current node url was not displayed

### DIFF
--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -101,7 +101,8 @@
             }
         },
         beforeMount() {
-            this.currentNodeUrl = this.$store.getters["Api/getNodeUrl"]
+            const apiCtx = Api.context(this.$store);apiCtx.getters.nodeUrl
+            this.currentNodeUrl = apiCtx.getters.nodeUrl
         },
         methods: {
             updateSettings() {


### PR DESCRIPTION
Forgot to update the call to the SettingsStore nodeUrl getter .